### PR TITLE
Permit optional definition of CCT_MODULES_PATH

### DIFF
--- a/dogen/cli.py
+++ b/dogen/cli.py
@@ -13,6 +13,8 @@ from dogen.errors import Error
 from dogen.plugin import Plugin
 
 import dogen.plugins.dist_git
+import dogen.plugins.cct
+import dogen.plugins.rpm
 
 class MyParser(argparse.ArgumentParser):
 

--- a/dogen/generator.py
+++ b/dogen/generator.py
@@ -199,7 +199,7 @@ class Generator(object):
             self.ssl_verify = True
 
         for plugin in self.plugins:
-            plugin.prepare()
+            plugin.prepare(cfg=self.cfg)
 
         if self.template:
             self._handle_custom_template()
@@ -225,7 +225,7 @@ class Generator(object):
         sources = self.handle_sources()
 
         for plugin in self.plugins:
-            plugin.after_sources(sources)
+            plugin.after_sources(files=sources)
 
         self.log.info("Finished!")
 

--- a/dogen/plugin.py
+++ b/dogen/plugin.py
@@ -9,9 +9,9 @@ class Plugin(object):
         self.log = dogen.log
         self.descriptor = dogen.descriptor
         self.output = dogen.output
-        
-    def prepare(self):
+
+    def prepare(self, **kwargs):
         pass
 
-    def after_sources(self):
+    def after_sources(self, **kwargs):
         pass

--- a/dogen/plugins/cct.py
+++ b/dogen/plugins/cct.py
@@ -1,0 +1,75 @@
+import os
+import yaml
+import subprocess
+import shutil
+
+from dogen.plugin import Plugin
+
+
+class CCT(Plugin):
+    @staticmethod
+    def info():
+        return "cct", "Support for configuring images via cct"
+
+    def __init__(self, dogen):
+        super(CCT, self).__init__(dogen)
+
+    def prepare(self, cfg):
+        """
+        create cct changes yaml file for image.yaml template decscriptor
+        it require cct aware template.jinja file
+        """
+        for module in self.find_modules(cfg['cct']['configure'][0]):
+            project, module_name = module.split('.', 1)
+            if project != 'base':
+                repo_path = cfg['cct']['modules_repo']
+                self.clone_repo(repo_path, project)
+                try:
+                    shutil.rmtree(self.output + '/cct')
+                except:
+                    pass # dir doesnt exists
+                self.append_sources(project, cfg)
+                os.makedirs(self.output + '/cct')
+                shutil.copytree(project, self.output + '/cct/' + project)
+                self.log.info("Cloned cct module %s." % project)
+        cfg_file = os.path.join(self.output, "cct", "cct.yaml")
+        cfg['cct']['run'] = ['cct.yaml']
+        with open(cfg_file, 'w') as f:
+            yaml.dump(cfg['cct']['configure'], f)
+
+    def clone_repo(self, url, path):
+        try:
+            if not os.path.exists(path):
+                subprocess.check_call(["git", "clone", url + path])
+        except Exception as ex:
+            self.log.error("cannot clone repo %s into %s: %s", url, path, ex)
+
+    def find_modules(self, cct_config):
+        repos = []
+        for modules in cct_config['changes']:
+            for module_name, ops in modules.items():
+                repos.append(module_name)
+        return repos
+
+    def append_sources(self, module, cfg):
+        sources_path = os.path.join(module, "sources.yaml")
+
+        source_prefix = os.getenv("DOGEN_CCT_SOURCES_PREFIX")
+        if source_prefix is None:
+            source_prefix = ""
+            self.log.debug("DOGEN_CCT_SOURCES_PREFIX variable is not provided")
+
+        with open(sources_path) as f:
+            cct_sources = yaml.load(f)
+
+            dogen_sources = []
+            for source in cct_sources:
+                dogen_source = {}
+                dogen_source['url'] = source_prefix + source['name']
+                print dogen_source['url']
+                dogen_source['hash'] = source['chksum']
+                dogen_sources.append(dogen_source)
+            try:
+                cfg['sources'].extend(dogen_sources)
+            except:
+                cfg['sources'] = dogen_sources

--- a/dogen/plugins/rpm.py
+++ b/dogen/plugins/rpm.py
@@ -1,0 +1,30 @@
+import os
+import shutil
+import glob
+
+from dogen.plugin import Plugin
+
+class RPM(Plugin):
+    @staticmethod
+    def info():
+        return "rpm","Support for injecting custom rpms"
+
+    def __init__(self, dogen):
+        super(RPM, self).__init__(dogen)
+        self.rpms_directory = os.path.join(os.path.dirname(self.descriptor), "rpms")
+
+    def prepare(self, cfg):
+        if not os.path.exists(self.rpms_directory):
+            return
+        self.log.info("Injecting custom rpms from %s" %self.rpms_directory)
+        rpms_path = os.path.join(self.output, "rpms")
+        if os.path.exists(rpms_path):
+            shutil.rmtree(rpms_path)
+        shutil.copytree(src=self.rpms_directory, dst=rpms_path)
+
+        rpms = glob.glob(os.path.join(self.output, "rpms", "*.rpm"))
+
+        self.log.debug("Found following additional rpm files: %s" % ", ".join(rpms))
+        cfg['rpms'] = []
+        for f in rpms:
+            cfg['rpms'].append(os.path.basename(f))

--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -106,7 +106,8 @@ RUN rm -rf /tmp/scripts
 # Run cct if needed
 {% if cct %}
 ADD cct /tmp/cct/
-RUN CCT_MODULES_PATH=/tmp/cct/ cct {%if cct.verbose %}-v{% endif %} {% for run in cct.run %} /tmp/cct/{{ run }} {% endfor %}
+RUN {%if cct.modules_path %}CCT_MODULES_PATH={{ cct.modules_path }}{% endif %} \
+    cct {%if cct.verbose %}-v{% endif %} {% for run in cct.run %} /tmp/cct/{{ run }} {% endfor %}
 
 # Add cct in command mode as entrypoint
 # you can specify path to changes files in CCT_CHANGES environemnt variable

--- a/dogen/templates/template.jinja
+++ b/dogen/templates/template.jinja
@@ -53,14 +53,18 @@ EXPOSE {%- for port in ports %} {{ port.value }}{% endfor %}
 
 USER root
 
-{% if packages %}
+{% if packages or rpms %}
 {% if additional_repos %}
 # Add custom repo files
 ADD scripts/*.repo /etc/yum.repos.d/
 {% endif %}
+{% if rpms %}
+# Add custom rpm files
+ADD rpms/*.rpm /tmp/rpms/
+{% endif %}
 
 # Install required RPMs
-RUN yum install -y {% if additional_repos -%} --disablerepo=\* {%- for repo in additional_repos %} --enablerepo={{ repo }}{% endfor %}{% endif %} {%- for package in packages %} {{ package }}{% endfor %} \
+RUN yum install -y {% if additional_repos -%} --disablerepo=\* {%- for repo in additional_repos %} --enablerepo={{ repo }}{% endfor %}{% endif %} {%- for package in packages %} {{ package }}{% endfor %} {%- for rpm in rpms %} /tmp/rpms/{{ rpm }} {% endfor %} \
     && yum clean all
 
 {% if additional_repos %}
@@ -92,10 +96,21 @@ USER {{ script.user }}
 RUN [ "bash", "-x", "/tmp/scripts/{{ script.package }}/{{ script.exec }}" ]
 
 {% endfor %}
+
 # Cleanup the scripts directory
 USER root
 RUN rm -rf /tmp/scripts
 
+{% endif %}
+
+# Run cct if needed
+{% if cct %}
+ADD cct /tmp/cct/
+RUN CCT_MODULES_PATH=/tmp/cct/ cct {%if cct.verbose %}-v{% endif %} {% for run in cct.run %} /tmp/cct/{{ run }} {% endfor %}
+
+# Add cct in command mode as entrypoint
+# you can specify path to changes files in CCT_CHANGES environemnt variable
+ENTRYPOINT ["/usr/bin/cct", "-c"]
 {% endif %}
 
 {%- if openshift %}
@@ -114,4 +129,3 @@ WORKDIR {{ workdir }}
 # Start the main process
 CMD {{ helper.cmd(cmd) }}
 {% endif %}
-


### PR DESCRIPTION
Allow user to define CCT_MODULES_PATH via cct::modules_path in the
YAML, rather than hard-coding to /tmp/cct. If not specified, cct
chooses its own default (which means you can use base.Shell etc.)
